### PR TITLE
Optional priviledge for chatlogs, tweak number of messages displayed, and other fixes.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -21,7 +21,7 @@ DEALINGS IN THE SOFTWARE.
 
 ]]
 local mod_storage = minetest.get_mod_storage()
-local number_of_messages = tonumber(settings:get("chatlogger.number_of_messages")) or 500
+local number_of_messages = tonumber(minetest.settings:get("chatlogger.number_of_messages")) or 500
 local needs_priv = minetest.settings:get_bool("chatlogger.needs_priv") or true
 local datetime_format = minetest.settings:get("chatlogger.datetime_format") or "%Y-%m-%d %H:%M:%S"
 

--- a/init.lua
+++ b/init.lua
@@ -21,7 +21,7 @@ DEALINGS IN THE SOFTWARE.
 
 ]]
 local mod_storage = minetest.get_mod_storage()
-local number_of_messages = tonumber(mod_storage:get_string("chatlogger.number_of_messages")) or 500
+local number_of_messages = tonumber(settings:get("chatlogger.number_of_messages")) or 500
 local needs_priv = minetest.settings:get_bool("chatlogger.needs_priv") or true
 local datetime_format = minetest.settings:get("chatlogger.datetime_format") or "%Y-%m-%d %H:%M:%S"
 

--- a/init.lua
+++ b/init.lua
@@ -20,8 +20,23 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 DEALINGS IN THE SOFTWARE.
 
 ]]
-
 local mod_storage = minetest.get_mod_storage()
+local number_of_messages = tonumber(mod_storage:get_string("chatlogger.number_of_messages")) or 500
+local needs_priv = minetest.settings:get_bool("chatlogger.needs_priv") or true
+local datetime_format = minetest.settings:get("chatlogger.datetime_format") or "%Y-%m-%d %H:%M:%S"
+
+local function get_formspec(message_list)
+  local formspec = {
+    "size[10,10]",
+    "label[0,0;" .. "# " .. minetest.colorize("orange", "CHAT LOGGER") .. " | Last " .. number_of_messages .. " messages...]",
+    "box[-0.1,-0.1;10,0.7;black]",
+    "box[-0.1,0.7;10,8.55;#030303]",
+    "textarea[0.2,0.7;10.2,10;;;" .. minetest.formspec_escape(table.concat(message_list, "\n")) .. "]",
+    "field[0.2,9.7;3,1;search;;]",
+    "button[2.85,9.34;2,1.1;search_button;Search]"
+  }
+  return table.concat(formspec)
+end
 
 local saved_messages = mod_storage:get_string("saved_messages")
 local message_list = {}
@@ -31,8 +46,8 @@ end
 
 local function register_message(message)
   message = message:gsub("%[", "("):gsub("%]", ")"):gsub("%.", ",")
-  table.insert(message_list, "# "..os.date("%Y-%m-%d %H:%M:%S").." | " .. message)
-  if #message_list > 100 then
+  table.insert(message_list, "# "..os.date(datetime_format).." | " .. message)
+  if #message_list > number_of_messages then
     table.remove(message_list, 1)
   end
 end
@@ -64,20 +79,16 @@ minetest.after(1, function()
   register_message("*** Server started!")
 end)
 
-minetest.register_chatcommand("chatlog", {
-  description = "Show the last 500 registered messages",
-  privs = {
-		interact = true
-	},
-  func = function(player_name)
-    local formspec = "size[10,10]"
-    formspec = formspec .. "label[0,0;" .. "# "..minetest.colorize("orange", "CHAT LOGGER").." | Last 500 messages..." .. "]"
-    formspec = formspec .. "box[-0.1,-0.1;10,0.7;black]"
-    formspec = formspec .. "box[-0.1,0.7;10,8.55;#030303]"
-    formspec = formspec .. "textarea[0.2,0.7;10.2,10;;;" .. table.concat(message_list, "\n") .. "]"
-    formspec = formspec .. "field[0.2,9.7;3,1;search;;]"
-    formspec = formspec .. "button[2.85,9.34;2,1.1;search_button;Search]"
+minetest.register_privilege("chatlogs", {
+  description = "Access to chat logs",
+  give_to_singleplayer = false,
+})
 
+minetest.register_chatcommand("chatlog", {
+  description = "Show the last "..number_of_messages.." registered messages",
+  privs = needs_priv and {chatlogs = true} or {},
+  func = function(player_name)
+    local formspec = get_formspec(message_list)
     minetest.show_formspec(player_name, "last_messages", formspec)
   end,
 })
@@ -92,13 +103,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
           table.insert(message_list_filtered, line)
         end
       end
-      local formspec = "size[10,10]"
-      formspec = formspec .. "label[0,0;" .. "# "..minetest.colorize("orange", "CHAT LOGGER").." | Search results for '" .. keyword .. "':" .. "]"
-      formspec = formspec .. "box[-0.1,-0.1;10,0.7;black]"
-      formspec = formspec .. "box[-0.1,0.7;10,8.55;#030303]"
-      formspec = formspec .. "textarea[0.2,0.7;10.2,10;;;" .. table.concat(message_list_filtered, "\n") .. "]"
-      formspec = formspec .. "field[0.2,9.7;3,1;search;;]"
-      formspec = formspec .. "button[2.85,9.34;2,1.1;search_button;Search]"
+      local formspec = get_formspec(message_list_filtered)
       minetest.show_formspec(player:get_player_name(), "search_results", formspec)
       return true
     end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,8 @@
+# Number of messages to be stored and displayed in chat logger
+chatlogger.number_of_messages (Number of messages) int 500
+
+# Whether the 'chatlogs' privilege is required to access chat logs
+chatlogger.needs_priv (Require 'chatlogs' privilege) bool true
+
+# Format of the datetime stamp in chat logs
+chatlogger.datetime_format (Datetime format) string %Y-%m-%d %H:%M:%S


### PR DESCRIPTION
# This PR adds the following
- Optional Privilege for chatlog command
- Ability to tweak number of messages displayed.
- Ability to tweak format of timestamp.

#Settings added:
## Number of messages to be stored and displayed in chat logger
`chatlogger.number_of_messages (Number of messages) int 500`

## Whether the 'chatlogs' privilege is required to access chat logs
`chatlogger.needs_priv (Require 'chatlogs' privilege) bool true`

## Format of the datetime stamp in chat logs
`chatlogger.datetime_format (Datetime format) string %Y-%m-%d %H:%M:%S`